### PR TITLE
chore(updatecli) ensure that only stable version of nginx are tracked

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,1 +1,1 @@
-parallelDockerUpdatecli([imageName: 'wiki', rebuildImageOnPeriodicJob: false, containerMemory: '512Mi'])
+parallelDockerUpdatecli([imageName: 'wiki', rebuildImageOnPeriodicJob: false, containerMemory: '1G'])

--- a/updatecli/updatecli.d/nginx.yaml
+++ b/updatecli/updatecli.d/nginx.yaml
@@ -1,49 +1,65 @@
 title: Bump nginx:stable docker image version
-sources:
-  latestRelease:
-    kind: githubRelease
-    name: Get latest nginx/nginx version
-    # We should retrieve only the minor even version to get the stable, but it requires an updatecli fix on its regexp parser, adding unwanted backslashes
+
+scms:
+  default:
+    kind: github
     spec:
-      owner: nginx
-      repository: nginx
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+  nginxGithubMirror:
+    kind: git
+    spec:
+      url: "https://github.com/nginx/nginx"
+      branch: "master"
+
+sources:
+  latestStableRelease:
+    name: Get latest stable version of nginx
+    kind: gitTag
+    scmID: nginxGithubMirror
+    spec:
       versionFilter:
-        kind: latest
+        kind: regex
+        ## Nginx stable version have the minor digit as an even number
+        pattern: 'release-(\d+)\.(\d*[0|2|4|6|8])\.(\d+)'
     transformers:
-    - trimPrefix: "release-"
-    - addSuffix: "-alpine"
-    # problem with nginxinc/docker-nginx repository: all tags aren't present in its releases
-    # spec:
-    #   owner: "nginxinc"
-    #   repository: "docker-nginx"
-    #   token: "{{ requiredEnv .github.token }}"
-    #   username: "{{ .github.username }}"
-    #   versionFilter:
-    #     kind: regexp
-    #     pattern: '(\d+)\.(\d*[0|2|4|6|8])\.(\d+)'
+      - trimPrefix: "release-"
+      - addSuffix: "-alpine"
+
 conditions:
   checkDockerImagePublished:
     name: "Test nginx:<latest_version> docker image tag"
     kind: dockerImage
+    sourceID: latestStableRelease
     spec:
       image: "nginx"
+      architecture: amd64
+      # tag comes from the sourceID
+
 targets:
   updateReleaseInDockerfile:
     name: "Update the version of nginx in the Dockerfile"
     kind: dockerfile
+    sourceID: latestStableRelease
     spec:
       file: Dockerfile
       instruction:
         keyword: "FROM"
         matcher: "nginx"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ .github.owner }}"
-        repository: "{{ .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateReleaseInDockerfile
+    spec:
+      labels:
+        - dependencies
+        - nginx


### PR DESCRIPTION
- Update nginx updatecli manifest to:
  - make it compliant with 0.18.3 (no more warnings or deprecated directives)
  - Only track the stable versions of nginx (minor version is alway even)
- Also define the pod to use 1Gb memory as updatecli seems to need more than 512 for retrieveing nginx tags
Closes #16 