### PR TITLE
fix: include MIME types in nginx configuration

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,5 +1,6 @@
 events {}
 http {
+    include /etc/nginx/mime.types;
     server {
         listen 80;
         server_name localhost _;


### PR DESCRIPTION
Fixes the MIME type issue for the CSS of wiki.jenkins-ci.org described in the jenkinsci-dev mailing list thread ["Jenkins Wiki CSS issues"](https://groups.google.com/g/jenkinsci-dev/c/mDL3TFv6WHY/m/SBd2dXzFFAAJ)

I agree the wiki shouldn't be that broken, the result before/after is far more better while sufficiently different than the other docs sites.

Until a proper deprecation banner is added as suggested or something equivalent<sup>`*`</sup>, I propose to restore the CSS for the wiki.

<details>
<summary>Current broken CSS:</summary>

![image](https://user-images.githubusercontent.com/91831478/193913854-640157a8-0292-4cdc-8a45-bf13a80c0150.png)


</details>

<details>
<summary>With fixed CSS:</summary>

![image](https://user-images.githubusercontent.com/91831478/193913434-14147a94-c58e-4658-8b2c-0c3699ec791c.png)


</details>

`*` This could be as simple as replacing the Atlassian logo image with one containing the butler and the deprecation message.
Quick and dirty, wouldn't need a replace in all pages.