### PR TITLE
Redirect "Dependencies among plugins" wiki page

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1619,6 +1619,7 @@ http {
             rewrite "^/display/JENKINS/Terminology$" "https://www.jenkins.io/doc/book/glossary/" permanent;
             rewrite "^/display/JENKINS/Jenkins\+CLI$" "https://www.jenkins.io/doc/book/managing/cli/" permanent;
             rewrite "^/display/JENKINS/Jenkins\+SSH$" "https://www.jenkins.io/doc/book/managing/cli/" permanent;
+            rewrite "^/display/JENKINS/Dependencies+among+plugins" "https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/" permanent;
             
             ## Developer documentation
             rewrite "^/display/JENKINS/Adopt\+a\+Plugin$" "https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/" permanent;


### PR DESCRIPTION
Redirect https://wiki.jenkins.io/display/JENKINS/Dependencies+among+plugins to https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/

As @timja [noted](https://github.com/jenkins-infra/jenkins.io/pull/5777#pullrequestreview-1212489135), this page has been split across two pages:
- [jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading](https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/)
- [jenkins.io/doc/developer/plugin-development/optional-dependencies/#plugin-statuses-and-behaviors](https://www.jenkins.io/doc/developer/plugin-development/optional-dependencies/#plugin-statuses-and-behaviors)

I've chose the first one as more complete for the redirection.

cc @basil

Ref: https://github.com/jenkins-infra/jenkins.io/pull/5777