### PR TITLE
chore:redirect building jenkisn wiki page to Building and Debugging jenkins.io

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1620,7 +1620,7 @@ http {
             rewrite "^/display/JENKINS/Jenkins\+CLI$" "https://www.jenkins.io/doc/book/managing/cli/" permanent;
             rewrite "^/display/JENKINS/Jenkins\+SSH$" "https://www.jenkins.io/doc/book/managing/cli/" permanent;
             rewrite "^/display/JENKINS/Dependencies\+among\+plugins" "https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/" permanent;
-            rewrite "^/display/JENKINS/Building\+Jenkins" "https://www.jenkins.io/doc/developer/building/#building-and-debugging/" permanent;
+            rewrite "^/display/JENKINS/Building\+Jenkins" "https://github.com/jenkinsci/jenkins/blob/master/CONTRIBUTING.md" permanent;
             
             ## Developer documentation
             rewrite "^/display/JENKINS/Adopt\+a\+Plugin$" "https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/" permanent;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1620,6 +1620,7 @@ http {
             rewrite "^/display/JENKINS/Jenkins\+CLI$" "https://www.jenkins.io/doc/book/managing/cli/" permanent;
             rewrite "^/display/JENKINS/Jenkins\+SSH$" "https://www.jenkins.io/doc/book/managing/cli/" permanent;
             rewrite "^/display/JENKINS/Dependencies\+among\+plugins" "https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/" permanent;
+            rewrite "^/display/JENKINS/Building\+Jenkins" "https://www.jenkins.io/doc/developer/building/#building-and-debugging/" permanent;
             
             ## Developer documentation
             rewrite "^/display/JENKINS/Adopt\+a\+Plugin$" "https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/" permanent;


### PR DESCRIPTION
Redirects https://wiki.jenkins.io/display/JENKINS/Building+Jenkins# to https://www.jenkins.io/doc/developer/building/#building-and-debugging/
see https://www.jenkins.io/doc/developer/building/#building-and-debugging/