### PR TITLE
Revert "chore: test https://github.com/jenkins-infra/pipeline-library/pull/834"

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,3 +1,1 @@
-@Library('pipeline-library@pull/834/head') _
-
 parallelDockerUpdatecli([imageName: 'wiki', rebuildImageOnPeriodicJob: false, updatecliConfig: [containerMemory: '1G'], buildDockerConfig : [targetplatforms: 'linux/amd64,linux/arm64']])


### PR DESCRIPTION
Reverts jenkins-infra/docker-confluence-data#52 as https://github.com/jenkins-infra/pipeline-library/pull/834 has been tested with success: https://github.com/jenkins-infra/docker-confluence-data/releases/tag/0.1.35