### PR TITLE
chore(updatecli) update cst file synchronously with nginx update

### DIFF
--- a/updatecli/updatecli.d/nginx.yaml
+++ b/updatecli/updatecli.d/nginx.yaml
@@ -46,6 +46,8 @@ targets:
     name: "Update the version of nginx in the Dockerfile"
     kind: dockerfile
     sourceid: latestStableRelease
+    transformers:
+      - addsuffix: "-alpine"
     spec:
       file: Dockerfile
       instruction:
@@ -56,13 +58,16 @@ targets:
     name: "Update the expectedError version in the test harness"
     sourceid: latestStableRelease
     scmid: default
-    kind: file
+    kind: yaml
+    transformers:
+      - findsubmatch:
+          pattern: '(\d+)\.(\d*[0|2|4|6|8])\.'
+          captureindex: 0
+      - addprefix: '"'
+      - addsuffix: '"'
     spec:
       file: "cst.yml"
-      matchpattern: >
-        expectedError: \["(.*)"]
-      replacepattern: >
-        expectedError: ["{{ source "latestStableRelease" }}"]
+      key: $.commandTests[0].expectedError[0]
 actions:
   default:
     kind: github/pullrequest

--- a/updatecli/updatecli.d/nginx.yaml
+++ b/updatecli/updatecli.d/nginx.yaml
@@ -29,24 +29,13 @@ sources:
         pattern: 'release-(\d+)\.(\d*[0|2|4|6|8])\.(\d+)'
     transformers:
       - trimprefix: "release-"
-      - addsuffix: "-alpine"
-  latestStableReleaseMainVersion:
-    name: Get Main Version latest stable version of nginx
-    kind: gittag
-    scmid: nginxGithubMirror
-    spec:
-      versionfilter:
-        kind: regex
-        ## Nginx stable version have the minor digit as an even number
-        pattern: 'release-(\d+)\.(\d*[0|2|4|6|8])\.(\d+)'
-    transformers:
-      - trimprefix: "release-"
-
 conditions:
   checkDockerImagePublished:
     name: "Test nginx:<latest_version> docker image tag"
     kind: dockerimage
     sourceid: latestStableRelease
+    transformers:
+      - addsuffix: "-alpine"
     spec:
       image: "nginx"
       architecture: amd64
@@ -65,7 +54,7 @@ targets:
     scmid: default
   updateTestHarness:
     name: "Update the expectedError version in the test harness"
-    sourceid: latestStableReleaseMainVersion
+    sourceid: latestStableRelease
     scmid: default
     kind: file
     spec:
@@ -73,7 +62,7 @@ targets:
       matchpattern: >
         expectedError: \["(.*)"]
       replacepattern: >
-        expectedError: ["{{ source "latestStableReleaseMainVersion" }}"]
+        expectedError: ["{{ source "latestStableRelease" }}"]
 actions:
   default:
     kind: github/pullrequest

--- a/updatecli/updatecli.d/nginx.yaml
+++ b/updatecli/updatecli.d/nginx.yaml
@@ -30,6 +30,17 @@ sources:
     transformers:
       - trimprefix: "release-"
       - addsuffix: "-alpine"
+  latestStableReleaseMainVersion:
+    name: Get Main Version latest stable version of nginx
+    kind: gittag
+    scmid: nginxGithubMirror
+    spec:
+      versionfilter:
+        kind: regex
+        ## Nginx stable version have the minor digit as an even number
+        pattern: 'release-(\d+)\.(\d*[0|2|4|6|8])\.(\d+)'
+    transformers:
+      - trimprefix: "release-"
 
 conditions:
   checkDockerImagePublished:
@@ -52,7 +63,17 @@ targets:
         keyword: "FROM"
         matcher: "nginx"
     scmid: default
-
+  updateTestHarness:
+    name: "Update the expectedError version in the test harness"
+    sourceid: latestStableReleaseMainVersion
+    scmid: default
+    kind: file
+    spec:
+      file: "cst.yml"
+      matchpattern: >
+        expectedError: \["(.*)"]
+      replacepattern: >
+        expectedError: ["{{ source "latestStableReleaseMainVersion" }}"]
 actions:
   default:
     kind: github/pullrequest


### PR DESCRIPTION
as per https://github.com/jenkins-infra/docker-confluence-data/pull/64#issuecomment-2110447675
the cst file need to be updated too