### PR TITLE
feat: prevent indexing pages referencing the accounts.jenkins.io application

### DIFF
--- a/content/JENKINS/User-Account-on-Jenkins.html
+++ b/content/JENKINS/User-Account-on-Jenkins.html
@@ -4,6 +4,7 @@
         <title>Jenkins : User Account on Jenkins</title>
         <link rel="stylesheet" href="styles/site.css" type="text/css" />
         <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <meta name="robots" content="noindex, nofollow" />
     </head>
 
     <body class="theme-default aui-theme-default">

--- a/content/infra/Account-Application.html
+++ b/content/infra/Account-Application.html
@@ -4,6 +4,7 @@
         <title>Jenkins Infrastructure : Account Application</title>
         <link rel="stylesheet" href="styles/site.css" type="text/css" />
         <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<meta name="robots" content="noindex, nofollow" />
     </head>
 
     <body class="theme-default aui-theme-default">


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4238

This PR adds the `meta` tags with `noindex` and `nofollow` as recommended by https://developers.google.com/search/docs/crawling-indexing/block-indexing to block indexing on these 2 specific pages