### PR TITLE
fix: replace "master" with "main"

### DIFF
--- a/content/JENKINS/Document-Jenkins.html
+++ b/content/JENKINS/Document-Jenkins.html
@@ -43,7 +43,7 @@
 
 <p><a href="https://jenkins.io" class="external-link" rel="nofollow">Jenkins.io</a> includes a <strong>Documentation</strong> section to provide product documentation beyond what is provided by the plugin pages specific to each plugin. This documentation is more focused on higher level use cases and concepts in Jenkins rather than just how to configure a feature or plugin.</p>
 
-<p>Contributing new documentation is done via the <a href="https://github.com/jenkins-infra/jenkins.io/blob/master/CONTRIBUTING.adoc#adding-documentation" class="external-link" rel="nofollow">Jenkins.io Github repository</a> and should be written in <a href="http://www.methods.co.nz/asciidoc/" class="external-link" rel="nofollow">AsciiDoc</a>.</p>
+<p>Contributing new documentation is done via the <a href="https://github.com/jenkins-infra/jenkins.io/blob/main/CONTRIBUTING.adoc#adding-documentation" class="external-link" rel="nofollow">Jenkins.io Github repository</a> and should be written in <a href="http://www.methods.co.nz/asciidoc/" class="external-link" rel="nofollow">AsciiDoc</a>.</p>
                     </div>
 
                     


### PR DESCRIPTION
#### Fixes [#7841](https://github.com/jenkins-infra/jenkins.io/pull/7841)

This PR is basically an extension of our primary PR in the jenkins.io repo.
We are on a larger mission to replace all master references to main .
This findings are of Kevin Sir ([his comment regarding this](https://github.com/jenkins-infra/jenkins.io/pull/7841#issuecomment-2755502715)) . Much thankful to him for his support