### PR TITLE
Adjust rewrite to capture more URLs

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -551,7 +551,7 @@ http {
             rewrite "^/display/JENKINS/GeneXus\+Plugin$" "https://plugins.jenkins.io/genexus" permanent;
             rewrite "^/display/JENKINS/Gerrit\+Verify\+Status\+Reporter\+Plugin$" "https://plugins.jenkins.io/gerrit-verify-status-reporter" permanent;
             rewrite "^/display/JENKINS/GitHub\+pull\+request\+builder\+plugin$" "https://plugins.jenkins.io/ghprb" permanent;
-            rewrite "^/display/JENKINS/Git\+Bisect$" "https://plugins.jenkins.io/git-bisect" permanent;
+            rewrite "^.*/JENKINS/Git\+Bisect" "https://plugins.jenkins.io/git-bisect" permanent;
             rewrite "^/display/JENKINS/Git\+Chooser\+Alternative\+Plugin$" "https://plugins.jenkins.io/git-chooser-alternative" permanent;
             rewrite "^/display/JENKINS/git\-notes\+Plugin$" "https://plugins.jenkins.io/git-notes" permanent;
             rewrite "^/display/JENKINS/Git\+Parameter\+Plugin$" "https://plugins.jenkins.io/git-parameter" permanent;


### PR DESCRIPTION
The goal of this PR is to update the regex/redirect structure to try and capture more URLs when redirecting.

Currently, the Git Bisect plugin docs regex is only redirecting if the URL is exactly `/display/JENKINS/Git\+Bisect$`. This means that if the URL deviates such as `https://wiki.jenkins.io/JENKINS/Git%2bBisect` or `https://wiki.jenkins.io/display/JENKINS/Git%2bBisect.html`, the redirect is not enforced and the link leads to the wiki page.

After meeting with @dduportal and @MarkEWaite we reviewed the current regex configuration and attempted updating the redirect syntax to be more flexible with the URL that it is acting on. With the suggested rewrite structure, when tested locally, the following output was received:

```
curl --output /dev/null --verbose "http://localhost/JENKINS/Git%2bBisect.html" 
* Host localhost:80 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying [::1]:80...
* Connected to localhost (::1) port 80
> GET /JENKINS/Git%2bBisect.html HTTP/1.1
> Host: localhost
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 301 Moved Permanently
< Server: nginx/1.28.0
< Date: Tue, 27 May 2025 15:17:28 GMT
< Content-Type: text/html
< Transfer-Encoding: chunked
< Connection: keep-alive
< Location: https://plugins.jenkins.io/git-bisect
```
The suggestion removes the `$` at the end of the URL so that it is not absolute in what it ends with and the `.*` at the beginning borrows from the google rewrite structure so that whatever might precede the page is included, regardless of whether the URL says `display`.

If this suggestion is applicable and not problematic, it would ideally be implemented for other rewrites. The end goal of updating the rewrites would be to account for more variance with URLs and ensure that links direct to the desired jenkins.io/plugins.jenkins.io page and to document the redirection process so that the developer & user docs can be updated accordingly. It would also make verifying the redirect much easier, as the current configuration can sometimes lead to inconsistencies (as described above).