### PR TITLE
Adjust Change Time Zone rewrite for more URL variables

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1585,7 +1585,7 @@ http {
             rewrite "^/display/JENKINS/Pipeline\+CPS\+method\+mismatches$" "https://www.jenkins.io/doc/book/pipeline/cps-method-mismatches/" permanent;
             rewrite "^/display/JENKINS/Meet\+Jenkins$" "https://www.jenkins.io/" permanent;
             rewrite "^/display/JENKINS/Home$" "https://www.jenkins.io/" permanent;
-            rewrite "^/display/JENKINS/Change\+time\+zone$" "https://www.jenkins.io/doc/book/using/change-time-zone/" permanent;
+            rewrite "^.*/JENKINS/Change\+time\+zone" "https://www.jenkins.io/doc/book/using/change-time-zone/" permanent;
             rewrite "^/display/JENKINS/Authenticating\+scripted\+clients$" "https://www.jenkins.io/doc/book/system-administration/authenticating-scripted-clients/" permanent;
             rewrite "^/display/JENKINS/Installing\+Jenkins\+as\+a\+Unix\+daemon$" "https://www.jenkins.io/doc/book/installing/" permanent;
             rewrite "^/display/JENKINS/Jenkins\+says\+my\+reverse\+proxy\+setup\+is\+broken$" "https://www.jenkins.io/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/" permanent;


### PR DESCRIPTION
Continuing from https://github.com/jenkins-infra/docker-confluence-data/pull/79, this PR adjusts the rewrite syntax for the Change Time Zone page. The goal is to do a few small adjustments (single entries) to test and verify that the redirects are working as intended before making larger changes.

The following was a tested URL that was originally not redirecting.

```
curl --output /dev/null --verbose "http://localhost/display/JENKINS/Change+time+zone.html"
* Host localhost:80 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying [::1]:80...
* Connected to localhost (::1) port 80
> GET /display/JENKINS/Change+time+zone.html HTTP/1.1
> Host: localhost
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 301 Moved Permanently
< Server: nginx/1.28.0
< Date: Fri, 30 May 2025 16:05:45 GMT
< Content-Type: text/html
< Transfer-Encoding: chunked
< Connection: keep-alive
< Location: https://www.jenkins.io/doc/book/using/change-time-zone/
< 
{ [768 bytes data]
100   756    0   756    0     0   112k      0 --:--:-- --:--:-- --:--:--  123k
* Connection #0 to host localhost left intact
```